### PR TITLE
Put the params in the body of the post request

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -32,9 +32,8 @@ post '/' do
     uri = URI.parse(url)
     query = Rack::Utils.parse_query(uri.query)
     query = forwardable_params.merge(query)
-    uri.query = Rack::Utils.build_query(query)
-    logger.info "POSTING TO: #{uri}"
-    HTTParty.post uri.to_s
+    logger.info "POSTING TO: #{uri}, BODY: #{Rack::Utils.build_query(query)}"
+    HTTParty.post( uri.to_s, body: query )
   end
 
   status 201


### PR DESCRIPTION
Some services (Slack, for example) require the params to be in the body of the request
